### PR TITLE
fix(workflow): Only add mounts to second container when the first con…

### DIFF
--- a/mutate.go
+++ b/mutate.go
@@ -169,7 +169,14 @@ func (s *server) mutate(request v1beta1.AdmissionRequest) (v1beta1.AdmissionResp
 	// If we have a Argo workflow, then lets run the logic
 	if _, ok := pod.ObjectMeta.Labels["workflows.argoproj.io/workflow"]; ok {
 		inject = true
-		containerIndex = 1
+
+		// Check the name of the first container in the pod.
+		// If it's called "wait", then we want to add the mount to the second container.
+		if pod.Spec.Containers[0].Name == "wait" {
+			containerIndex = 1
+		} else {
+			containerIndex = 0
+		}
 	}
 
 	if inject {


### PR DESCRIPTION
…tainer is wait

Otherwise, we just add them to the first container