### PR TITLE
feat(injection): Remove mounts of old MinIO instances

### DIFF
--- a/mutate.go
+++ b/mutate.go
@@ -180,8 +180,8 @@ func (s *server) mutate(request v1beta1.AdmissionRequest) (v1beta1.AdmissionResp
 	}
 
 	if inject {
-		patches = append(patches, s.addBoathouseInstance("minimal-minio-tenant1", "minio_minimal_tenant1", "https://minimal-tenant1-minio.covid.cloud.statcan.ca", defaultRegion, profile, "/home/jovyan/minio/minimal-tenant1", containerIndex)...)
-		patches = append(patches, s.addBoathouseInstance("premium-minio-tenant1", "minio_premium_tenant1", "https://premium-tenant1-minio.covid.cloud.statcan.ca", defaultRegion, profile, "/home/jovyan/minio/premium-tenant1", containerIndex)...)
+		// patches = append(patches, s.addBoathouseInstance("minimal-minio-tenant1", "minio_minimal_tenant1", "https://minimal-tenant1-minio.covid.cloud.statcan.ca", defaultRegion, profile, "/home/jovyan/minio/minimal-tenant1", containerIndex)...)
+		// patches = append(patches, s.addBoathouseInstance("premium-minio-tenant1", "minio_premium_tenant1", "https://premium-tenant1-minio.covid.cloud.statcan.ca", defaultRegion, profile, "/home/jovyan/minio/premium-tenant1", containerIndex)...)
 		patches = append(patches, s.addBoathouseInstance("premium-minio-tenant-1", "minio_premium_tenant_1", "https://minio-premium-tenant-1.covid.cloud.statcan.ca", defaultRegion, profile, "/home/jovyan/minio/premium-tenant-1", containerIndex)...)
 		patches = append(patches, s.addBoathouseInstance("standard-minio-tenant-1", "minio_standard_tenant_1", "https://minio-standard-tenant-1.covid.cloud.statcan.ca", defaultRegion, profile, "/home/jovyan/minio/standard-tenant-1", containerIndex)...)
 


### PR DESCRIPTION
This is to prevent workload blocking due to failing MinIO instances.